### PR TITLE
fix for hard-coded .bct

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -249,18 +249,14 @@
   flex-grow: 1;
 }
 
-.theme-dark .loom-bct {
-  color: #808080;
+.loom-bct {
+  color: var(--text-muted);
 }
 
 .theme-dark .loom-bct-border {
-  border-right: 2px dashed #808080;
+  border-right: 2px dashed #333;
 }
 
-.theme-light .loom-bct {
-  color: #999;
-}
-
-.theme-dark .loom-bct-hover {
-  background-color: #111;
+.loom-bct-hover {
+  background-color: var(--background-secondary);
 }


### PR DESCRIPTION
hey! love the plugin, but i noticed you use .them-light and .theme-dark for the .bct selector; this causes issues with themes since the color values are hardcoded --i hope you don't mind but i went ahead and updated it to use 1.0 variables instead :)

*i left the border alone because i couldn't discern what it controls.