### PR TITLE
reduce editor lag by making render async and preventing too many renders

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -85,6 +85,8 @@ const DEFAULT_SETTINGS: LoomSettings = {
 
 type CompletionResult = { ok: true; completions: string[] } | { ok: false; status: number; message: string };
 
+let renderBusy = false;
+
 export default class LoomPlugin extends Plugin {
   settings: LoomSettings;
   state: Record<string, NoteState>;
@@ -103,8 +105,13 @@ export default class LoomPlugin extends Plugin {
 
   saveAndRender() {
 	this.save();
+  if (renderBusy) return;
+
+  renderBusy = true;
 	this.renderLoomViews();
 	this.renderLoomSiblingsViews();
+  renderBusy = false;
+
   }
 
   thenSaveAndRender(callback: () => void) {
@@ -676,7 +683,10 @@ export default class LoomPlugin extends Plugin {
           );
 
           updateDecorations();
-		  this.saveAndRender();
+
+          setTimeout(() => {
+            this.saveAndRender();
+          }, 0);
 		  
           // restore cursor position
           editor.setCursor(cursor);


### PR DESCRIPTION
this reduces the editor lag when the tree is big
most of the lag was caused by the renderLoomViews (which can be .5 seconds for a large tree) being called every time the editor updated
I made the call to renderLoomViews asynchronous so that it wouldn't block the editor, and added a renderBusy variable which prevents the render functions from being called if a previous call hasn't finished.